### PR TITLE
Feature/20170829 rlw

### DIFF
--- a/lib/s3-model.coffee
+++ b/lib/s3-model.coffee
@@ -1,33 +1,32 @@
-# All the ways that the code base interacts with s3
-# http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html
-# This is to be used in the v2 api and in the image service
-fs             = require 'fs'
-path           = require 'path'
-HOMEDIR        = path.join(__dirname)
-LIB_COV        = path.join(HOMEDIR,'lib-cov')
-LIB_DIR        = if fs.existsSync(LIB_COV) then LIB_COV else path.join(HOMEDIR)
-config         = require(path.join(LIB_DIR,'config')).config.init()
-AWS            = require('aws-sdk')
-default_folder = 'teamone-files-new'
+AWS                    = require('aws-sdk')
+DEFAULT_DEFAULT_FOLDER = 'default-folder'
 
+# Interacts with AWS S3.
+# See http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html
 class S3Model
-  constructor:(@pool) ->
 
-    AWS.config.credentials = config.get('s3')
-    if not config.get 's3'
-      console.log """WARNING: You did not set any credentials for s3 in your config, all S3 files and routes will fail. Also, make js-tests will fail.
-        You need something like this in your config:
-
-        "s3": =>
-          "access_key_id":"xxxxxxxx",
-          "secret_access_key": "xxxxxx/IHJ+c",
-          "region":"us-east-1"
-        }"""
-
+  # `config` may be:
+  #  - `default_folder` - S3 folder name used when otherwise `null`
+  #  - `credentials` - AWS credentials object, generally containing:
+  #      - `access_key_id`
+  #      - `secret_access_key`
+  #      - `region`
+  # alternatively, `config` may be an AWS credentials object
+  # (directly containing `access_key_id`, `secret_access_key`, `region`).
+  constructor:(config)->
+    config ?= {}
+    @default_folder = config.default_folder ? "default-folder"
+    if config.credentials?
+      AWS.config.credentials = config.credentials
+    else if config.access_key_id?
+      AWS.config.credentials = config
+    unless AWS.config.credentials?
+      console.warn "WARNING: S3Model created but no AWS credentials have been set. You may want to pass `{access_key_id:, secret_access_key:, region: }` to the S3Model constructor."
     @s3 = new AWS.S3
       endpoint: 's3.amazonaws.com',
       signature_version: 'v4'
 
+  # callback:(err, aws_response)
   create_folder: (folder_name, callback) =>
     folder_name = @_sanitize_folder_name folder_name
     data =
@@ -35,6 +34,7 @@ class S3Model
     @s3.createBucket data, (err, response) ->
       callback err, response
 
+  # callback:(err, aws_response)
   delete_folder: (folder_name, callback) =>
     folder_name = @_sanitize_folder_name(folder_name)
     data =
@@ -42,10 +42,12 @@ class S3Model
     @s3.deleteBucket data, (err, response) ->
       callback err, response
 
+  # callback:(err, aws_response)
   get_all_folders: (callback) =>
     @s3.listBuckets {}, (err, response) ->
       callback err, response
 
+  # callback:(err, folder_exists)
   folder_exists: (folder_name, callback) =>
     folder_name = @_sanitize_folder_name(folder_name)
     data =
@@ -53,6 +55,7 @@ class S3Model
     @s3.getBucketLocation data, (err, response) ->
       callback err, not err and response?
 
+  # callback:(err, aws_response)
   create_file: (folder_name, filename, file_type, body, callback) =>
     folder_name = @_sanitize_folder_name folder_name
     data =
@@ -62,18 +65,19 @@ class S3Model
       ContentType: file_type
     @create_folder folder_name, (err, created_folder) =>
       @s3.putObject data, (err, response) ->
-        console.log err if err
         callback err, response
 
+  # callback:(err, url)
   get_file: (folder_name, filename, callback) =>
     folder_name = @_sanitize_folder_name(folder_name)
     data =
       Bucket: folder_name,
       Key: filename,
-      Expires: 86400 # Default is one day
+      Expires: 86400 # Default is one day - TODO: should probably make this configurable
     @s3.getSignedUrl 'getObject', data, (err, url) ->
       callback err, url
 
+  # callback:(err, aws_response)
   get_meta_data: (folder_name, filename, callback) =>
     folder_name = @_sanitize_folder_name(folder_name)
     data =
@@ -82,15 +86,17 @@ class S3Model
     @s3.headObject data, (err, response) ->
       callback err, response
 
+  # callback:(err, aws_response)
   update_file: (folder_name, filename, file_type, body, callback) =>
     folder_name = @_sanitize_folder_name(folder_name)
     data =
       Bucket: folder_name,
       Key: filename
-    @delete_file folder_name, filename, (err, deleted_file) =>
+    @delete_file folder_name, filename, (err, deleted_file) => # TODO - are we sure we want to ignore errors here?
       @create_file folder_name, filename, file_type, body, (err, created_file) ->
         callback err, created_file
 
+  # callback:(err, aws_response)
   delete_file: (folder_name, filename, callback) =>
     folder_name = @_sanitize_folder_name(folder_name)
     data =
@@ -99,9 +105,8 @@ class S3Model
     @s3.deleteObject data, (err, response) ->
       callback err, response
 
+  # returns a valid folder name (defaulting to `@default_folder` when `null`)
   _sanitize_folder_name: (folder_name)->
-    if not folder_name
-      folder_name = default_folder
-    return folder_name
+    return folder_name ? @default_folder
 
 exports.S3Model = S3Model

--- a/test/test-s3-model.coffee
+++ b/test/test-s3-model.coffee
@@ -1,88 +1,98 @@
-fs                  = require 'fs'
-path                = require 'path'
-HOMEDIR             = path.join(__dirname,'..')
-LIB_COV             = path.join(HOMEDIR,'lib-cov')
-LIB_DIR             = if fs.existsSync(LIB_COV) then LIB_COV else path.join(HOMEDIR,'lib')
-S3Model             = require(path.join(LIB_DIR,'s3-model')).S3Model
-assert              = require('assert')
+fs        = require 'fs'
+path      = require 'path'
+HOME_DIR  = path.join(__dirname,'..')
+LIB_COV   = path.join(HOME_DIR,'lib-cov')
+LIB_DIR   = if fs.existsSync(LIB_COV) then LIB_COV else path.join(HOME_DIR,'lib')
+S3Model   = require(path.join(LIB_DIR,'s3-model')).S3Model
+assert    = require('assert')
+config    = require(path.join(LIB_DIR,'config')).config.init()
+S3_CONFIG = config.get("s3")
 
-s3 = undefined
+if not S3_CONFIG?
+  console.warn """
+    WARNING: S3 configuration not provided so S3Model tests will be skipped.
+             Set:
+               {s3:{access_key_id:"",secret_access_key:"",region:""}}
+             in your configuration to avoid this warning.
+  """
 
-describe 'S3Model', () ->
+else
 
-  before (done) ->
-    # BDBT.before_each ->
-    s3 = new S3Model({pool: {}})
-    s3.create_folder 'test_folder-7635364', (err, results) ->
-      if err
-        s3.delete_folder 'test_folder-7635364', (err, results) ->
-          s3.create_folder 'test_folder-7635364', (err, results) ->
+  s3 = undefined
+
+  describe 'S3Model', () ->
+
+    before (done) ->
+      s3 = new S3Model(S3_CONFIG)
+      s3.create_folder 'test_folder-7635364', (err, results) ->
+        if err
+          s3.delete_folder 'test_folder-7635364', (err, results) ->
+            s3.create_folder 'test_folder-7635364', (err, results) ->
+              done()
+        else
+          done()
+
+    after (done) ->
+      done()
+
+    describe 'Folder Management', () ->
+
+      it 'should create a folder', (done) ->
+        s3.create_folder 'sample_folder', (err, results) ->
+          assert.equal results.Location, '/sample_folder'
+          done()
+
+      it 'should list all folders', (done) ->
+        s3.get_all_folders (err, results) ->
+          bucket_names = results.Buckets.map (bucket) ->
+            return bucket.Name
+          assert bucket_names.includes 'sample_folder'
+          done()
+
+      it 'should check if a folder exists', (done) ->
+        s3.folder_exists 'test_folder-7635364', (err, found_folder) ->
+          assert.equal found_folder, true
+          done()
+
+      it 'should delete a folder', (done) ->
+        s3.delete_folder 'sample_folder', (err, results) ->
+          assert.deepEqual results, {}
+          done()
+
+    describe 'File Management', () ->
+
+      it 'should create a file', (done) ->
+        body = Buffer.from [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a]
+        s3.create_file 'test_folder-7635364', 'testFile123', 'image/png', body, (err, created_file) ->
+          assert created_file.ETag?
+          done()
+
+      it 'should create a file in a folder that does not exist and create that folder', (done) ->
+        folder_name = 'magically-created-folder-323'
+        filename = 'testFile123'
+        body = Buffer.from [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a]
+        contentType = 'image/png'
+        s3.create_file folder_name, filename, contentType, body, (err, created_file) ->
+          assert created_file.ETag?
+          s3.folder_exists folder_name, (err, found_folder) ->
+            assert found_folder
             done()
-      else
-        done()
 
-  after (done) ->
-    # BDBT.before_each ->
-    done()
+      it 'should create a file in the default folder and then find it', (done) ->
+        body = Buffer.from [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a]
+        s3.create_file 'my_folder', 'fake_file.png', 'image/png', body, (err, created_file) ->
+          assert created_file.ETag
+          s3.get_file null, 'fake_file.png', (err, found_file) ->
+            assert found_file.match(/.*Expires.*/).length > 0
+            assert found_file.match(/https:\/\/.*s3\.amazonaws\.com.*\/fake_file\.png.*/).length > 0
+            done()
 
-  describe 'Folder Management', () ->
-
-    it 'should create a folder', (done) ->
-      s3.create_folder 'sample_folder', (err, results) ->
-        assert.equal results.Location, '/sample_folder'
-        done()
-
-    it 'should list all folders', (done) ->
-      s3.get_all_folders (err, results) ->
-        bucket_names = results.Buckets.map (bucket) ->
-          return bucket.Name
-        assert bucket_names.includes 'sample_folder'
-        done()
-
-    it 'should check if a folder exists', (done) ->
-      s3.folder_exists 'test_folder-7635364', (err, found_folder) ->
-        assert.equal found_folder, true
-        done()
-
-    it 'should delete a folder', (done) ->
-      s3.delete_folder 'sample_folder', (err, results) ->
-        assert.deepEqual results, {}
-        done()
-
-  describe 'File Management', () ->
-
-    it 'should create a file', (done) ->
-      body = Buffer.from [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a]
-      s3.create_file 'test_folder-7635364', 'testFile123', 'image/png', body, (err, created_file) ->
-        assert created_file.ETag?
-        done()
-
-    it 'should create a file in a folder that does not exist and create that folder', (done) ->
-      folder_name = 'magically-created-folder-323'
-      filename = 'testFile123'
-      body = Buffer.from [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a]
-      contentType = 'image/png'
-      s3.create_file folder_name, filename, contentType, body, (err, created_file) ->
-        assert created_file.ETag?
-        s3.folder_exists folder_name, (err, found_folder) ->
-          assert found_folder
+      it 'should get the file', (done) ->
+        s3.get_file 'test_folder-7635364', 'testFile123', (err, found_file) ->
+          assert found_file.match(/.*Expires.*/)
           done()
 
-    it 'should create a file in the default folder and then find it', (done) ->
-      body = Buffer.from [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a]
-      s3.create_file 'my_folder', 'fake_file.png', 'image/png', body, (err, created_file) ->
-        assert created_file.ETag
-        s3.get_file null, 'fake_file.png', (err, found_file) ->
-          assert found_file.match(/.*Expires.*/).length > 0
-          assert found_file.match(/https:\/\/.*s3\.amazonaws\.com.*\/fake_file\.png.*/).length > 0
+      it 'should delete a file', (done) ->
+        s3.delete_file 'test_folder-7635364', 'testFile123', (err, deleted_file) ->
+          assert deleted_file, {}
           done()
-
-    it 'should get the file', (done) ->
-      s3.get_file 'test_folder-7635364', 'testFile123', (err, found_file) ->
-        assert found_file.match(/.*Expires.*/)
-        done()
-
-    it 'should delete a file', (done) ->
-      s3.delete_file 'test_folder-7635364', 'testFile123', (err, deleted_file) ->
-        assert deleted_file, {}
-        done()


### PR DESCRIPTION
@joncodo I'd like to make the following changes to S3Model (described in the commits below) but note that this will require a small change to the way the S3Model constructor is called.

The TL;DR change is to convert:

```js
foo = new S3Model()
```

to

```js
foo = new S3Model(config.get("s3"))
```

Also I changed the team-one-specific default folder name (to just `default-folder`). It can be specified in the config/constructor using:

```json
{
  "s3": {
    "default-folder": "teamone-files-new",
    "credentials": {
      "access_key_id": "etc."
    }
}
```

Any feedback/concerns/suggestions w.r.t. this?
  